### PR TITLE
[TIMOB-26106] Update module apiversion

### DIFF
--- a/windows/CMakeLists.txt
+++ b/windows/CMakeLists.txt
@@ -21,7 +21,7 @@ project(TiXamlListView)
 
 set(TiXamlListView_VERSION 0.1.0)
 
-set(WINDOWS_SOURCE_DIR "C:/ProgramData/Titanium/mobilesdk/win32/7.1.1.GA/windows")
+set(WINDOWS_SOURCE_DIR "C:/ProgramData/Titanium/mobilesdk/win32/7.3.0.GA/windows")
 
 SET(CMAKE_FIND_LIBRARY_PREFIXES "")
 SET(CMAKE_FIND_LIBRARY_SUFFIXES ".lib" ".dll")

--- a/windows/manifest
+++ b/windows/manifest
@@ -3,8 +3,8 @@
 # during compilation, packaging, distribution, etc.
 #
 
-version: 1.1.1
-apiversion: 5 
+version: 1.2.0
+apiversion: 6
 architectures: ARM x86
 description: ti.xaml.listview
 author: Kota Iguchi
@@ -18,4 +18,4 @@ moduleIdAsIdentifier: TiXamlListView
 classname: Ti::UI::WindowsXaml::ListView
 guid: c17fec33-4f98-4194-8fc2-be86dedd0874
 platform: windows
-minsdk: 7.1.1.GA
+minsdk: 7.3.0


### PR DESCRIPTION
[TIMOB-26106](https://jira.appcelerator.org/browse/TIMOB-26106)

Update module apiversion for Windows because there's module binary incompatibility in upcoming sdk 7.3.0.